### PR TITLE
Check for array before looping to stop PHP warning.

### DIFF
--- a/includes/class-flagpole.php
+++ b/includes/class-flagpole.php
@@ -299,6 +299,10 @@ class Flagpole {
 			// We have a user.
 			$groups = self::get_user( $user_id, $meta_key, true );
 
+			if ( ! is_array( $groups ) ) {
+				return $response;
+			}
+
 			foreach ( $groups as $group => $index ) {
 				$group_obj = self::get_group( $group );
 


### PR DESCRIPTION
Was noticing some PHP Warnings locally when no groups were set up for
user enforced flags.