### PR TITLE
Flag labels - provides subheadings for flag list

### DIFF
--- a/includes/admin/settings-page/settings-page-flags.php
+++ b/includes/admin/settings-page/settings-page-flags.php
@@ -5,102 +5,111 @@
  * @package flagpole
  */
 
+use Flagpole\Flagpole;
+
+$flagpole_available_labels = Flagpole::init()->get_unique_labels();
 ?>
 
 <?php if ( $flagpole_available_flags ) { ?>
 
 	<h2>Available flags</h2>
 
-	<table class="widefat flags_table">
-		<thead>
-		<tr>
-			<th class="row-title">Feature</th>
-			<th>Key</th>
-			<th>Description</th>
-			<th>Visibility</th>
-			<th colspan="2">Actions</th>
-		</tr>
-		</thead>
-		<tbody>
-
-		<?php foreach ( $flagpole_available_flags as $flagpole_key => $flagpole_flag ) { ?>
-
-			<?php $flagpole_enabled = flagpole_user_enabled( $flagpole_flag->get_key( false ) ); ?>
-			<?php $flagpole_published = $flagpole_flag->is_published(); ?>
-
-			<tr class="<?php echo( 0 === $flagpole_key % 2 ? null : 'alternate' ); ?>">
-				<td class="title">
-					<strong><?php wp_kses_post( $flagpole_flag->get_name() ); ?></strong>
-				</td>
-				<td>
-					<code><?php $flagpole_flag->get_key(); ?></code>
-				</td>
-				<td><?php $flagpole_flag->get_description(); ?></td>
-				<td>
-					<?php
-
-					if ( $flagpole_enabled ) {
-						submit_button(
-							'Disable preview',
-							'small',
-							'featureFlagsBtn_disable',
-							false,
-							[
-								'class'       => 'action-btn',
-								'data-action' => 'toggleFeatureFlag',
-								'data-status' => 'enabled',
-							]
-						);
-					} else {
-						submit_button(
-							'Enable preview',
-							'primary small',
-							'featureFlagsBtn_enable',
-							false,
-							[
-								'class'       => 'action-btn',
-								'data-action' => 'toggleFeatureFlag',
-								'data-status' => 'disabled',
-							]
-						);
-					}
-					?>
-
-				</td><td>
-					<?php
-
-					$flagpole_stable       = $flagpole_flag->is_stable( false );
-					$flagpole_button_style = ( $flagpole_stable ? 'primary small' : 'small' );
-					$flagpole_button_text  = ( $flagpole_published ? 'Unpublish' : 'Publish' );
-					$flagpole_button_name  = ( $flagpole_published ? 'featureFlagsBtn_unpublish' : 'featureFlagsBtn_publish' );
-					$flagpole_other_args   = [
-						'data-action' => 'togglePublishedFeature',
-					];
-
-					if ( ! $flagpole_stable ) {
-						$flagpole_other_args['disabled'] = true;
-						$flagpole_button_text            = 'Disabled';
-						$flagpole_other_args['title']    = 'Feature is marked as unstable.';
-					}
-
-					submit_button(
-						$flagpole_button_text,
-						$flagpole_button_style,
-						$flagpole_button_name,
-						false,
-						$flagpole_other_args
-					);
-
-					?>
-
-				</td>
-			</tr>
-
+	<?php foreach ( $flagpole_available_labels as $flagpole_label ) { ?>
+		<?php if ( count( $flagpole_available_labels ) > 1 ) { ?>
+			<h4><?php echo esc_html( $flagpole_label ); ?></h4>
 		<?php } ?>
 
-		</tbody>
-	</table>
+		<table class="widefat flags_table">
+			<thead>
+			<tr>
+				<th class="row-title">Feature</th>
+				<th>Key</th>
+				<th>Description</th>
+				<th>Visibility</th>
+				<th colspan="2">Actions</th>
+			</tr>
+			</thead>
+			<tbody>
 
+			<?php foreach ( $flagpole_available_flags as $flagpole_key => $flagpole_flag ) { ?>
+				<?php if ( $flagpole_label === $flagpole_flag->get_label( false ) ) { ?>
+
+					<?php $flagpole_enabled = flagpole_user_enabled( $flagpole_flag->get_key( false ) ); ?>
+					<?php $flagpole_published = $flagpole_flag->is_published(); ?>
+
+					<tr class="<?php echo( 0 === $flagpole_key % 2 ? null : 'alternate' ); ?>">
+						<td class="title">
+							<strong><?php wp_kses_post( $flagpole_flag->get_name() ); ?></strong>
+						</td>
+						<td>
+							<code><?php $flagpole_flag->get_key(); ?></code>
+						</td>
+						<td><?php $flagpole_flag->get_description(); ?></td>
+						<td>
+							<?php
+
+							if ( $flagpole_enabled ) {
+								submit_button(
+									'Disable preview',
+									'small',
+									'featureFlagsBtn_disable',
+									false,
+									[
+										'class'       => 'action-btn',
+										'data-action' => 'toggleFeatureFlag',
+										'data-status' => 'enabled',
+									]
+								);
+							} else {
+								submit_button(
+									'Enable preview',
+									'primary small',
+									'featureFlagsBtn_enable',
+									false,
+									[
+										'class'       => 'action-btn',
+										'data-action' => 'toggleFeatureFlag',
+										'data-status' => 'disabled',
+									]
+								);
+							}
+							?>
+
+						</td><td>
+							<?php
+
+							$flagpole_stable       = $flagpole_flag->is_stable( false );
+							$flagpole_button_style = ( $flagpole_stable ? 'primary small' : 'small' );
+							$flagpole_button_text  = ( $flagpole_published ? 'Unpublish' : 'Publish' );
+							$flagpole_button_name  = ( $flagpole_published ? 'featureFlagsBtn_unpublish' : 'featureFlagsBtn_publish' );
+							$flagpole_other_args   = [
+								'data-action' => 'togglePublishedFeature',
+							];
+
+							if ( ! $flagpole_stable ) {
+								$flagpole_other_args['disabled'] = true;
+								$flagpole_button_text            = 'Disabled';
+								$flagpole_other_args['title']    = 'Feature is marked as unstable.';
+							}
+
+							submit_button(
+								$flagpole_button_text,
+								$flagpole_button_style,
+								$flagpole_button_name,
+								false,
+								$flagpole_other_args
+							);
+
+							?>
+
+						</td>
+					</tr>
+				<?php } ?>
+			<?php } ?>
+
+			</tbody>
+		</table>
+	<?php } ?>
 <?php } ?>
 
 <?php if ( $flagpole_enforced_flags ) { ?>

--- a/includes/class-flag.php
+++ b/includes/class-flag.php
@@ -71,6 +71,13 @@ class Flag {
 	public $stable;
 
 	/**
+	 * A label for the flag to belong to.
+	 *
+	 * @var string
+	 */
+	public $label;
+
+	/**
 	 * Flag constructor.
 	 *
 	 * @param string $_key The Key for the feature.
@@ -78,13 +85,15 @@ class Flag {
 	 * @param bool   $_enforced Is the key enforced.
 	 * @param string $_description The description to be shown in the admin about the field.
 	 * @param bool   $_stable Allow this flag to be published or not.
+	 * @param string $_label The subsection of the feature flag list. Defaults to 'all'.
 	 */
-	public function __construct( $_key, $_name, $_enforced, $_description, $_stable ) {
+	public function __construct( $_key, $_name, $_enforced, $_description, $_stable, $_label ) {
 		$this->enforced    = $_enforced;
 		$this->name        = ( $_name ? $_name : '' );
 		$this->key         = $_key;
 		$this->description = $_description;
 		$this->stable      = $_stable;
+		$this->label       = ( $_label ? $_label : 'All' );
 	}
 
 	/**
@@ -132,6 +141,22 @@ class Flag {
 			echo wp_kses_post( $description );
 		} else {
 			return $description;
+		}
+	}
+
+	/**
+	 * Display or retrieve the flag label.
+	 *
+	 * @param boolean $echo Echo or return the response.
+	 * @return null|string Current label text if $echo is false.
+	 */
+	public function get_label( $echo = true ) {
+		$label = $this->label;
+
+		if ( $echo ) {
+			echo wp_kses_post( $label );
+		} else {
+			return $label;
 		}
 	}
 

--- a/includes/class-flagpole.php
+++ b/includes/class-flagpole.php
@@ -153,7 +153,7 @@ class Flagpole {
 	 * @return void
 	 */
 	public function add_flag( $flag ) {
-		$this->flags[] = new Flag( $flag['key'], $flag['title'], $flag['enforced'], $flag['description'], $flag['stable'] );
+		$this->flags[] = new Flag( $flag['key'], $flag['title'], $flag['enforced'], $flag['description'], $flag['stable'], $flag['label'] );
 	}
 
 	/**
@@ -682,6 +682,24 @@ class Flagpole {
 		}
 
 		update_option( $key, maybe_serialize( $groups ) );
+	}
+
+	/**
+	 * Returns an alphabetically sorted array of unique labels.
+	 *
+	 * @return array
+	 */
+	public function get_unique_labels() {
+		$flags = $this->flags;
+		$all_labels = [];
+
+		foreach( $flags as $flag ) {
+			$all_labels[] = $flag->label;
+		}
+
+		$unique_labels = array_unique( $all_labels );
+		asort( $unique_labels );
+		return $unique_labels;
 	}
 }
 


### PR DESCRIPTION
Allows for 'label' value to be set against any feature flag, with a default of 'All'.

Groups all flags by label in the admin list page.

Gives user groupings of flags in the adlin list page, for easier management of long lists of flags.